### PR TITLE
Add absolute possessive (theirs) pronoun and refactor gender keys to they/them

### DIFF
--- a/code/commands/general/CommandSay.cs
+++ b/code/commands/general/CommandSay.cs
@@ -50,7 +50,7 @@ namespace inspiral
 
 			if(invocation.Length <= 0)
 			{
-				invoker.ShowNearby(invoker, $"You open your mouth but say nothing.", $"{invoker.GetShort()} opens {invoker.gender.His} mouth but says nothing.");
+				invoker.ShowNearby(invoker, $"You open your mouth but say nothing.", $"{invoker.GetShort()} opens {invoker.gender.Their} mouth but says nothing.");
 				invoker.SendPrompt();
 				return;
 			}

--- a/code/commands/general/CommandStrike.cs
+++ b/code/commands/general/CommandStrike.cs
@@ -129,7 +129,7 @@ namespace inspiral
 				BodypartComponent body = (BodypartComponent)strikeWith.GetComponent(Text.CompBodypart);
 				if(body.isNaturalWeapon)
 				{
-					strikeString = $"{invoker.gender.His} {strikeString}";
+					strikeString = $"{invoker.gender.Their} {strikeString}";
 				}
 			}
 

--- a/code/components/InventoryComponent.cs
+++ b/code/components/InventoryComponent.cs
@@ -366,7 +366,7 @@ namespace inspiral
 				{
 					parent.ShowNearby(parent, 
 						$"You equip {equipping.GetShort()} to your {slot}.",
-						$"{Text.Capitalize(parent.GetShort())} equips {equipping.GetShort()} to {parent.gender.His} {slot}."
+						$"{Text.Capitalize(parent.GetShort())} equips {equipping.GetShort()} to {parent.gender.Their} {slot}."
 					);
 				}
 				Game.Objects.QueueForUpdate(parent);
@@ -403,7 +403,7 @@ namespace inspiral
 					}
 					parent.ShowNearby(parent, 
 						$"You remove {unequipping.GetShort()} from your {removingSlot}.",
-						$"{Text.Capitalize(parent.GetShort())} removes {unequipping.GetShort()} from {parent.gender.His} {removingSlot}."
+						$"{Text.Capitalize(parent.GetShort())} removes {unequipping.GetShort()} from {parent.gender.Their} {removingSlot}."
 					);
 					Game.Objects.QueueForUpdate(parent);
 				}

--- a/code/components/PhysicsComponent.cs
+++ b/code/components/PhysicsComponent.cs
@@ -307,7 +307,7 @@ namespace inspiral
 			}
 			else
 			{
-				You = Text.Capitalize(parent.gender.He);
+				You = Text.Capitalize(parent.gender.They);
 				are = parent.gender.Is;
 				if(are == "is")
 				{

--- a/code/components/VisibleComponent.cs
+++ b/code/components/VisibleComponent.cs
@@ -117,15 +117,15 @@ namespace inspiral
 				else
 				{
 					startingToken = "That's";
-					theyAre = $"{Text.Capitalize(parent.gender.He)} {parent.gender.Is}";
-					their = Text.Capitalize(parent.gender.His);
+					theyAre = $"{Text.Capitalize(parent.gender.They)} {parent.gender.Is}";
+					their = Text.Capitalize(parent.gender.Their);
 				}
 
 				MobileComponent mob = (MobileComponent)parent.GetComponent(Text.CompMobile);
 				mainDesc = $"{startingToken} {mainDesc}\n{theyAre} a {mob.race}";
 				if(viewer == parent)
 				{
-					mainDesc += $". When people look at you, they see:\n{Text.Capitalize(parent.gender.He)} {parent.gender.Is} a {mob.race}";
+					mainDesc += $". When people look at you, they see:\n{Text.Capitalize(parent.gender.They)} {parent.gender.Is} a {mob.race}";
 				}
 				if(examinedDescription == null || examinedDescription.Length <= 0)
 				{

--- a/code/display/Text.cs
+++ b/code/display/Text.cs
@@ -254,7 +254,7 @@ namespace inspiral
 			Console.WriteLine(message);
 			if(message.ToLower().Contains($"${token}"))
 			{
-				string replacementValue = thirdPerson ? other.gender.He : "you";
+				string replacementValue = thirdPerson ? other.gender.They : "you";
 				message = Regex.Replace(
 					message,
 					$"\\${token}_(he|she|they|ey)\\$",
@@ -266,7 +266,7 @@ namespace inspiral
 					return message;
 				}
 
-				replacementValue = thirdPerson ? other.gender.His : "your";
+				replacementValue = thirdPerson ? other.gender.Their : "your";
 				message = Regex.Replace(
 					message,
 					$"\\${token}_(his|her|their|eir)\\$",
@@ -278,7 +278,7 @@ namespace inspiral
 					return message;
 				}
 
-				replacementValue = thirdPerson ? other.gender.Him : "you";
+				replacementValue = thirdPerson ? other.gender.Them : "you";
 				message = Regex.Replace(
 					message,
 					$"\\${token}_(him|her|them|em)\\$",

--- a/code/modules/ModuleGender.cs
+++ b/code/modules/ModuleGender.cs
@@ -20,12 +20,13 @@ namespace inspiral
 
 	internal class GenderObject
 	{
-		internal string Term = null;
-		internal string His  = null;
-		internal string Him  = null;
-		internal string He   = null;
-		internal string Is   = null;
-		internal string Self = null;
+        internal string They   = null;
+        internal string Them   = null;
+        internal string Their  = null;
+        internal string Theirs = null;
+		internal string Is     = null;
+        internal string Self   = null;
+        internal string Term   = null;
 	}
 	internal class GenderModule : GameModule
 	{
@@ -42,15 +43,18 @@ namespace inspiral
 				try
 				{
 					Dictionary<string, string> genderStrings = JsonConvert.DeserializeObject<Dictionary<string, string>>(File.ReadAllText(f.File));
-					GenderObject  gender = new GenderObject();
-					gender.He =   genderStrings["He"];
-					gender.Him =  genderStrings["Him"];
-					gender.His =  genderStrings["His"];
-					gender.Is =   genderStrings["Is"];
-					gender.Term = genderStrings["Term"];
-					gender.Self = genderStrings["Self"];
-					genders.Add(gender.Term, gender);
-					foreach(string token in new List<string>() {gender.He, gender.Him, gender.His, gender.Is, gender.Self})
+                    var gender = new GenderObject
+                    {
+                        They =   genderStrings["They"],
+                        Them =   genderStrings["Them"],
+                        Their =  genderStrings["Their"],
+                        Theirs = genderStrings["Theirs"],
+                        Is =     genderStrings["Is"],
+                        Self =   genderStrings["Self"],
+                        Term =   genderStrings["Term"]
+                    };
+                    genders.Add(gender.Term, gender);
+					foreach(string token in new List<string>() {gender.They, gender.Them, gender.Their, gender.Theirs, gender.Is, gender.Self})
 					{
 						if(!Tokens.Contains(token))
 						{

--- a/code/objects/GameObjectDisplay.cs
+++ b/code/objects/GameObjectDisplay.cs
@@ -131,7 +131,7 @@ namespace inspiral
 			{
 				if(HasComponent(Text.CompInventory))
 				{
-					string their = (this == viewer) ? "your" : gender.His;
+					string their = (this == viewer) ? "your" : gender.Their;
 					InventoryComponent equip = (InventoryComponent)GetComponent(Text.CompInventory);
 					foreach(KeyValuePair<string, GameObject> equ in equip.carrying)
 					{

--- a/data/definitions/genders/gender_female.json
+++ b/data/definitions/genders/gender_female.json
@@ -1,8 +1,9 @@
 {
-  "He" :   "she",
-  "Him" :  "her",
-  "His" :  "her",
-  "Is" :   "is",
-  "Self" : "self",
-  "Term" : "female"
+  "They" :   "she",
+  "Them" :   "her",
+  "Their" :  "her",
+  "Theirs" : "hers",
+  "Is" :     "is",
+  "Self" :   "self",
+  "Term" :   "female"
 }

--- a/data/definitions/genders/gender_inanimate.json
+++ b/data/definitions/genders/gender_inanimate.json
@@ -1,8 +1,9 @@
 {
-  "He" :   "it",
-  "Him" :  "it",
-  "His" :  "its",
-  "Is" :   "is",
-  "Self" : "self",
-  "Term" : "inanimate"
+  "They" :   "it",
+  "Them" :   "it",
+  "Their" :  "its",
+  "Theirs" : "its",
+  "Is" :     "is",
+  "Self" :   "self",
+  "Term" :   "inanimate"
 }

--- a/data/definitions/genders/gender_male.json
+++ b/data/definitions/genders/gender_male.json
@@ -1,8 +1,9 @@
 {
-  "He" :   "he",
-  "Him" :  "him",
-  "His" :  "his",
-  "Is" :   "is",
-  "Self" : "self",
-  "Term" : "male"
+  "They" :   "he",
+  "Them" :   "him",
+  "Their" :  "his",
+  "Theirs" : "his",
+  "Is" :     "is",
+  "Self" :   "self",
+  "Term" :   "male"
 }

--- a/data/definitions/genders/gender_neuter.json
+++ b/data/definitions/genders/gender_neuter.json
@@ -1,6 +1,6 @@
 {
-  "They" :   "it",
-  "Them" :   "it",
+  "They" :   "ey",
+  "Them" :   "em",
   "Their" :  "eir",
   "Theirs" : "eirs",
   "Is" :     "is",

--- a/data/definitions/genders/gender_neuter.json
+++ b/data/definitions/genders/gender_neuter.json
@@ -1,8 +1,9 @@
 {
-  "He" :   "ey",
-  "Him" :  "em",
-  "His" :  "eir",
-  "Is" :   "is",
-  "Self" : "self",
-  "Term" : "neuter"
+  "They" :   "it",
+  "Them" :   "it",
+  "Their" :  "eir",
+  "Theirs" : "eirs",
+  "Is" :     "is",
+  "Self" :   "self",
+  "Term" :   "neuter"
 }

--- a/data/definitions/genders/gender_plural.json
+++ b/data/definitions/genders/gender_plural.json
@@ -1,8 +1,9 @@
 {
-  "He" :   "they",
-  "Him" :  "them",
-  "His" :  "their",
-  "Is" :   "are",
-  "Self" : "selves",
-  "Term" : "plural"
+  "They" :   "they",
+  "Them" :   "them",
+  "Their" :  "their",
+  "Theirs" : "theirs",
+  "Is" :     "are",
+  "Self" :   "selves",
+  "Term" :   "plural"
 }


### PR DESCRIPTION
Once the absolute possessive ("theirs") is added, he/him and she/her would both make poor keys since they both have collisions (his/their, his/theirs; her/them, her/their).

Refactored references to these keys and made some minor edits to keep pronoun sets in the same they/them/their/theirs/is/self/term order